### PR TITLE
Problem: can speed up iterations with ccache

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -12,6 +12,10 @@ fi
 (which gsl >/dev/null 2>&1) && \
 	gsl project.xml
 
+[ -d "/usr/lib/ccache" ] && \
+    PATH="/usr/lib/ccache:$PATH" && \
+    export PATH
+
 ./autogen.sh && \
 ./configure && \
 echo "=== MAKING PAR" && \


### PR DESCRIPTION
Solution: builder.sh now refers to ccache if available to speed up rebuilds
